### PR TITLE
Refactor road objects into dataclasses

### DIFF
--- a/src/ssoss/dynamic_road_object.py
+++ b/src/ssoss/dynamic_road_object.py
@@ -20,7 +20,15 @@ from ssoss.static_road_object import Intersection, StaticRoadObject
 
 class DynamicRoadObject:
 
-    def __init__(self, id_num, name, obj_type, sro_df, gpx_df, source="GPX"):
+    def __init__(
+        self,
+        id_num: int,
+        name: str,
+        obj_type: str,
+        sro_df: pd.DataFrame,
+        gpx_df: pd.DataFrame,
+        source: str = "GPX",
+    ) -> None:
         """Dynamic Road Objects move through time and space using a source (typ. GPX)
 
         :param id_num: unique ID number for object
@@ -73,7 +81,7 @@ class DynamicRoadObject:
     def mask(df, key, value) -> pd.DataFrame:
         return df[df[key] == value]
 
-    def update_location_simple(self, i=2):
+    def update_location_simple(self, i: int = 2) -> None:
         """ Update dynamic object location with new data point i
         """
         self.t0 = self.t1
@@ -98,7 +106,7 @@ class DynamicRoadObject:
         t = datetime.fromisoformat(str(self.t1))
         return pd.Timestamp(t)
 
-    def first_utc_timestamp(self):
+    def first_utc_timestamp(self) -> float:
         t = self.t0.timetuple()
         return time.mktime(t) - 28800
 
@@ -111,17 +119,17 @@ class DynamicRoadObject:
         return time.mktime(t) - 28800
 
     @staticmethod
-    def utc_to_timestamp(t):
+    def utc_to_timestamp(t: float) -> str:
         return time.asctime(time.localtime(t))
 
-    def get_time_step(self):
+    def get_time_step(self) -> float:
         time_step = self.t1 - self.t0
         if time_step.total_seconds() < 0:
             return 10.0  # assume larger first gpx point time step
         else:
             return time_step.total_seconds()
 
-    def get_location(self, i=None, elev=False):
+    def get_location(self, i: int | None = None, elev: bool = False) -> str:
         if elev:
             if i is None:
                 return self.pnt1.format_decimal()
@@ -498,11 +506,11 @@ class DynamicRoadObject:
         )
 
     @staticmethod
-    def find_index(df, i):
+    def find_index(df: pd.DataFrame, i: int) -> pd.Series:
         return df.iloc[i]
 
     @staticmethod
-    def t_spd_adjust(d0, spd0, d1, spd1):
+    def t_spd_adjust(d0: float, spd0: float, d1: float, spd1: float) -> float:
         """ Adjusts time of event based on speed of gpx points i and i+1.
 
         :param d0: distance a t=0

--- a/src/ssoss/process_road_objects.py
+++ b/src/ssoss/process_road_objects.py
@@ -223,17 +223,29 @@ class ProcessRoadObjects:
                 columns_in_row = len(row)
                 if columns_in_row == 13:
                     self.intersection_load["id"].append(int(row[0]))
-                    self.intersection_load["intersection_obj"].append(Intersection(
-                        id_num = int(row[0]),
-                        # name1(N/S), name2(E/W)
-                        name = tuple((str(row[1]),str(row[2]))),
-                        ctr_pnt = geopy.Point(float(row[3]),float(row[4])),
-                        # spd_N, spd_E, spd_S, spd_W
-                        spd = tuple((int(row[5]), int(row[6]), int(row[7]),int(row[8]))),
-                        # bearing_N, bearing_E, bearing_S, bearing_W
-                        bearing = tuple((float(row[9]), float(row[10]), float(row[11]),
-                            float(row[12])))
-                    ))
+                    self.intersection_load["intersection_obj"].append(
+                        Intersection(
+                            int(row[0]),
+                            tuple((str(row[1]), str(row[2]))),
+                            geopy.Point(float(row[3]), float(row[4])),
+                            spd=tuple(
+                                (
+                                    int(row[5]),
+                                    int(row[6]),
+                                    int(row[7]),
+                                    int(row[8]),
+                                )
+                            ),
+                            bearing=tuple(
+                                (
+                                    float(row[9]),
+                                    float(row[10]),
+                                    float(row[11]),
+                                    float(row[12]),
+                                )
+                            ),
+                        )
+                    )
                 elif columns_in_row == 29:
                     nb_sb_pts = eb_sb_pts = sb_sb_pts = wb_sb_pts = False
                     if (row[13] and row[14] and
@@ -247,29 +259,29 @@ class ProcessRoadObjects:
 
                     self.intersection_load["id"].append(int(row[0]))
                     temp_i = Intersection(
-                        id_num = int(row[0]),
-                        # name1(N/S), name2(E/W)
-                        name = tuple((str(row[1]),str(row[2]))),
-                        ctr_pnt = geopy.Point(float(row[3]),float(row[4])),
-                        # spd_N, spd_E, spd_S, spd_W
-                        spd = tuple((int(row[5]), int(row[6]), int(row[7]),
-                            int(row[8]))),
-                        # bearing_N, bearing_E, bearing_S, bearing_W
-                        bearing = tuple((float(row[9]), float(row[10]), float(row[11]),
-                            float(row[12]))),
-                        # Additional info for stop bar to improve accuracy:
-                        # NB Stop bar. center line Point(lat, lon), shoulder Point(lat, lon)
-                        stop_bar_nb = tuple((geopy.Point(row[13], row[14]),
-                            geopy.Point(row[15], row[16]))),
-                        # EB Stop bar. center line Point(lat, lon), shoulder Point(lat, lon)
-                        stop_bar_eb = tuple((geopy.Point(row[17], row[18]),
-                            geopy.Point(row[19], row[20]))),
-                        # SB Stop bar. center line Point(lat, lon), shoulder Point(lat, lon)
-                        stop_bar_sb = tuple((geopy.Point(row[21], row[22]),
-                            geopy.Point(row[23], row[24]))),
-                        # WB Stop bar. center line Point(lat, lon), shoulder Point(lat, lon)
-                        stop_bar_wb = tuple((geopy.Point(row[25], row[26]),
-                            geopy.Point(row[27], row[28])))
+                        int(row[0]),
+                        tuple((str(row[1]), str(row[2]))),
+                        geopy.Point(float(row[3]), float(row[4])),
+                        spd=tuple(
+                            (
+                                int(row[5]),
+                                int(row[6]),
+                                int(row[7]),
+                                int(row[8]),
+                            )
+                        ),
+                        bearing=tuple(
+                            (
+                                float(row[9]),
+                                float(row[10]),
+                                float(row[11]),
+                                float(row[12]),
+                            )
+                        ),
+                        stop_bar_nb=tuple((geopy.Point(row[13], row[14]), geopy.Point(row[15], row[16]))),
+                        stop_bar_eb=tuple((geopy.Point(row[17], row[18]), geopy.Point(row[19], row[20]))),
+                        stop_bar_sb=tuple((geopy.Point(row[21], row[22]), geopy.Point(row[23], row[24]))),
+                        stop_bar_wb=tuple((geopy.Point(row[25], row[26]), geopy.Point(row[27], row[28]))),
                     )
                     temp_i.set_sb_pts_bools((nb_sb_pts,eb_sb_pts,sb_sb_pts,wb_sb_pts))
                     self.intersection_load["intersection_obj"].append(temp_i)

--- a/tests/test_static_road_object.py
+++ b/tests/test_static_road_object.py
@@ -16,9 +16,12 @@ class TestGetIDNumMethod(unittest.TestCase):
         55: 625,
         60: 715
     }
-    test_sro = StaticRoadObject(100, "street_name", "test_object", \
-                                geopy.Point(37.79205307308094, -122.40918793416158), \
-                                speed_sightD_tuple)
+    test_sro = StaticRoadObject(
+        100,
+        "street_name",
+        geopy.Point(37.79205307308094, -122.40918793416158),
+        spd_sd=speed_sightD_tuple,
+    )
     sro_id_result = test_sro.get_id_num()
 
     def test_get_id_num_type(self):
@@ -49,15 +52,17 @@ class TestDistanceToSB(unittest.TestCase):
     intersection_stop_bar_wb = (geopy.Point(37.792081947979, -122.40908296974182),
                                 geopy.Point(37.792137440921714, -122.40909664953729))
 
-    test_intersection = Intersection(100,
-                                     intersection_name,
-                                     intersection_ctr_pt,
-                                     intersection_spd_tuple,
-                                     intersection_bearing,
-                                     intersection_stop_bar_nb,
-                                     intersection_stop_bar_eb,
-                                     intersection_stop_bar_sb,
-                                     intersection_stop_bar_wb)
+    test_intersection = Intersection(
+        100,
+        intersection_name,
+        intersection_ctr_pt,
+        spd=intersection_spd_tuple,
+        bearing=intersection_bearing,
+        stop_bar_nb=intersection_stop_bar_nb,
+        stop_bar_eb=intersection_stop_bar_eb,
+        stop_bar_sb=intersection_stop_bar_sb,
+        stop_bar_wb=intersection_stop_bar_wb,
+    )
 
     test_nb_approach_point = geopy.Point(37.791640829945806, -122.4090598924283)
     test_eb_approach_point = geopy.Point(37.79191109041387, -122.41001431676943)


### PR DESCRIPTION
## Summary
- convert `StaticRoadObject`, `GenericStaticObject` and `Intersection` into dataclasses
- add optional type hints to dynamic road object methods
- adjust calls and tests to new dataclass constructors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684527722a28832b9105fb52b8d28158