### PR TITLE
Fix output directory handling

### DIFF
--- a/src/ssoss/dynamic_road_object.py
+++ b/src/ssoss/dynamic_road_object.py
@@ -71,7 +71,8 @@ class DynamicRoadObject:
         )
 
         self.in_file_path = PurePath("./in/")
-        self.out_file_path = PurePath("./out/")
+        self.out_file_path = Path("./out")
+        self.out_file_path.mkdir(exist_ok=True, parents=True)
 
         if self.spd is None:
             self.calculate_spd_values()

--- a/src/ssoss/process_road_objects.py
+++ b/src/ssoss/process_road_objects.py
@@ -45,8 +45,8 @@ class ProcessRoadObjects:
         self.pretty_datetime_format = "%y-%m-%d %H:%M:%S"
         self.in_gpx_dir_path = Path(gpx_filestring).parent
         self.in_dir_path = self.in_gpx_dir_path
-        self.out_dir_path = Path(self.in_dir_path, "/out/") #  self.in_dir_path / "out/"
-        self.out_dir_path.parent.mkdir(exist_ok=True, parents=True)
+        self.out_dir_path = self.in_dir_path / "out"
+        self.out_dir_path.mkdir(exist_ok=True, parents=True)
 
         # init variables
         #if signals_filestring:

--- a/src/ssoss/process_video.py
+++ b/src/ssoss/process_video.py
@@ -27,8 +27,8 @@ class ProcessVideo:
         self.video_dir = Path(video_filestring).parents[0]
         self.video_filepath = Path(video_filestring)
         self.video_filename = Path(video_filestring).name
-        self.image_out_path = self.video_dir / "out/"
-        self.image_out_path.parent.mkdir(exist_ok=True, parents=True)
+        self.image_out_path = self.video_dir / "out"
+        self.image_out_path.mkdir(exist_ok=True, parents=True)
 
         self.fps = self.get_fps()
         self.frame_count = self.get_frame_count()


### PR DESCRIPTION
## Summary
- fix output directory path and creation in ProcessRoadObjects
- fix ProcessVideo output directory initialization
- ensure DynamicRoadObject creates `out` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684786fe7a00832bbd499f206c45ad49