### PR TITLE
Fix center_to_sb_distance attribute error

### DIFF
--- a/src/ssoss/static_road_object.py
+++ b/src/ssoss/static_road_object.py
@@ -286,10 +286,13 @@ class Intersection(StaticRoadObject):
         return (nb and eb and sb and wb)
     
     def center_to_sb_distance(self, bearing_index):
-        """not used"""
+        """Return the distance from the intersection center to the stop bar.
+
+        The intersection center point is stored in ``ctr_pt``.
+        """
         min_distance = min(
-            geopy.distance.distance(self.ctr_pnt, self.stop_bar_d[bearing_index][0]).ft,
-            geopy.distance.distance(self.ctr_pnt, self.stop_bar_d[bearing_index][1]).ft
+            geopy.distance.distance(self.ctr_pt, self.stop_bar_d[bearing_index][0]).ft,
+            geopy.distance.distance(self.ctr_pt, self.stop_bar_d[bearing_index][1]).ft,
         )
         return min_distance
     

--- a/tests/test_static_road_object.py
+++ b/tests/test_static_road_object.py
@@ -100,5 +100,37 @@ class TestDistanceToSB(unittest.TestCase):
         self.assertLess(self.wb_result, 215)
 
 
+class TestIntersectionHelpers(unittest.TestCase):
+    """Ensure helper methods on :class:`Intersection` execute correctly."""
+
+    intersection_name = ("California", "Powell")
+    intersection_ctr_pt = geopy.Point(37.79205307308094, -122.40918793416158)
+    intersection_spd_tuple = (25, 25, 25, 25)
+    intersection_bearing = (346.33, 90.09, 174.52, 271.11)
+    intersection_stop_bar_nb = (
+        geopy.Point(37.791939238323664, -122.40915035636318),
+        geopy.Point(37.79194559709975, -122.4091101232288),
+    )
+
+    test_intersection = Intersection(
+        101,
+        intersection_name,
+        intersection_ctr_pt,
+        spd=intersection_spd_tuple,
+        bearing=intersection_bearing,
+        stop_bar_nb=intersection_stop_bar_nb,
+    )
+
+    def test_get_location_sb_runs(self):
+        """``get_location_sb`` should return a ``geopy.Point`` without error."""
+        pt = self.test_intersection.get_location_sb(0)
+        self.assertIsInstance(pt, geopy.Point)
+
+    def test_center_to_sb_distance_runs(self):
+        """``center_to_sb_distance`` should return a numeric distance."""
+        dist = self.test_intersection.center_to_sb_distance(0)
+        self.assertIsInstance(dist, float)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- fix use of `ctr_pt` in `center_to_sb_distance`
- ensure `get_location_sb` and `center_to_sb_distance` run without errors

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c4de8294832bb0be6a0d12dbb032