### PR TITLE
Fix duration formatting for video summary

### DIFF
--- a/src/ssoss/process_road_objects.py
+++ b/src/ssoss/process_road_objects.py
@@ -594,15 +594,14 @@ class ProcessRoadObjects:
         if sec < 60:
             return f'{sec} seconds'
         elif sec < 3600:
-            min = int(sec/60)
-            sec_remain = round(sec - min * 60, 2)
-            return f'{min}:{sec_remain} (MM:SS.ss)'
+            minutes = int(sec / 60)
+            sec_remain = round(sec - minutes * 60, 2)
+            return f'{minutes:02}:{sec_remain:05.2f} (MM:SS.ss)'
         elif sec >= 3600:
-            hr = int(sec/3600)
-            min_remain = round(sec - hr * 3600, 2)
-            min = int(min_remain/60)
-            sec_remain = round(sec - min * 60, 2)
-            return f'{hr}:{min}:{sec_remain} (HH:MM:SS.ss)'
+            hr = int(sec / 3600)
+            minutes = int((sec - hr * 3600) / 60)
+            sec_remain = round(sec - (hr * 3600 + minutes * 60), 2)
+            return f'{hr:02}:{minutes:02}:{sec_remain:05.2f} (HH:MM:SS.ss)'
 
     @staticmethod
     def simplify_distance(d_ft):

--- a/src/ssoss/process_video.py
+++ b/src/ssoss/process_video.py
@@ -349,8 +349,8 @@ class ProcessVideo:
             return f'{minutes:02}:{sec_remain:05.2f} (MM:SS.ss)'
         elif sec >= 3600:
             hr = int(sec / 3600)
-            minutes = int(sec / 60)
-            sec_remain = round(sec - minutes * 60, 2)
+            minutes = int((sec - hr * 3600) / 60)
+            sec_remain = round(sec - (hr * 3600 + minutes * 60), 2)
             return f'{hr:02}:{minutes:02}:{sec_remain:05.2f} (HH:MM:SS.ss)'
 
     def sizeConvert(self, size):

--- a/tests/test_hr_min_sec.py
+++ b/tests/test_hr_min_sec.py
@@ -1,0 +1,38 @@
+import unittest
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from ssoss.process_video import ProcessVideo
+from ssoss.process_road_objects import ProcessRoadObjects
+
+
+class TestHrMinSec(unittest.TestCase):
+    def test_seconds_only(self):
+        self.assertEqual(ProcessVideo.hr_min_sec(50), "50 seconds")
+        self.assertEqual(ProcessRoadObjects.hr_min_sec(50), "50 seconds")
+
+    def test_minutes_seconds(self):
+        self.assertEqual(
+            ProcessVideo.hr_min_sec(125.8),
+            "02:05.80 (MM:SS.ss)"
+        )
+        self.assertEqual(
+            ProcessRoadObjects.hr_min_sec(125.8),
+            "02:05.80 (MM:SS.ss)"
+        )
+
+    def test_hours_minutes_seconds(self):
+        self.assertEqual(
+            ProcessVideo.hr_min_sec(3661.2),
+            "01:01:01.20 (HH:MM:SS.ss)"
+        )
+        self.assertEqual(
+            ProcessRoadObjects.hr_min_sec(3661.2),
+            "01:01:01.20 (HH:MM:SS.ss)"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- correct hour/minute/second calculation in `hr_min_sec`
- update both `process_video` and `process_road_objects`
- add regression tests for `hr_min_sec`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ccc277dc832ba5cf85fd932936a4