### PR TITLE
Bump project version to 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ssoss"
-version = "0.5.01"
+version = "1.0"
 authors = [
   { name="Matt Redmond", email="mr2742@gmail.com" },
 ]

--- a/src/ssoss/__init__.py
+++ b/src/ssoss/__init__.py
@@ -16,5 +16,5 @@ try:
     __version__ = importlib.metadata.version("ssoss")
 except importlib.metadata.PackageNotFoundError:
     # Package metadata not found when running from source
-    __version__ = "0.0.0"
+    __version__ = "1.0"
 


### PR DESCRIPTION
## Summary
- set project version to 1.0 in `pyproject.toml`
- update fallback version in `src/ssoss/__init__.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_6848344fb540832ba7ae23d2657a5a06