### PR TITLE
Add GIF cleanup and overwrite options

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ While SSOSS does provide approximate sight distance images, their are various so
 Create a gif from multiple images around the sight distance location. This can be helpful if the lens is out of focus or an few frames are obstructed.
 
 Include the -- gif flag in the command line to create. Note: this requires additional processing time for large video files.
+Use --gif-overwrite to replace an existing GIF and --no-gif-cleanup to keep the extracted frames.
 
 Saves .gif file in ./out/[video filename]/gif/
 

--- a/src/ssoss/ssoss_cli.py
+++ b/src/ssoss/ssoss_cli.py
@@ -9,7 +9,7 @@ def args_static_obj_gpx_video(
     video_file="",
     vid_sync=("", ""),
     frame_extract=("", ""),
-    extra_out=(True, False),
+    extra_out=(True, False, True, False),
 ):
 
     sightings = ""
@@ -38,12 +38,22 @@ def args_static_obj_gpx_video(
             if sightings and project.get_static_object_type() == "intersection":
                 print("extracting traffic signal sightings")
                 video.extract_sightings(
-                    sightings, project, label_img=extra_out[0], gen_gif=extra_out[1]
+                    sightings,
+                    project,
+                    label_img=extra_out[0],
+                    gen_gif=extra_out[1],
+                    cleanup=extra_out[2],
+                    overwrite=extra_out[3],
                 )
             if sightings and project.get_static_object_type() == "generic static object":
                 print("extracting generic static object sightings")
                 video.extract_generic_so_sightings(
-                    sightings, project, label_img=extra_out[0], gen_gif=extra_out[1]
+                    sightings,
+                    project,
+                    label_img=extra_out[0],
+                    gen_gif=extra_out[1],
+                    cleanup=extra_out[2],
+                    overwrite=extra_out[3],
                 )
         elif frame_extract[0] and frame_extract[1]:
             print("extracting frames...")
@@ -143,6 +153,20 @@ def main():
         help="Add bounding box around traffic signals",
         action="store_true",
     )
+    video_sync_group.add_argument(
+        "--no-gif-cleanup",
+        dest="gif_cleanup",
+        help="Keep extracted GIF frames after assembly",
+        action="store_false",
+        default=True,
+    )
+    video_sync_group.add_argument(
+        "--gif-overwrite",
+        dest="gif_overwrite",
+        help="Overwrite existing GIF files",
+        action="store_true",
+        default=False,
+    )
 
     # process args depending on filled in values
     args = parser.parse_args()
@@ -161,7 +185,9 @@ def main():
         gif = True
     if args.bbox:
         bbox = True
-    lb_gif_bbox = (lb, gif, bbox)
+    cleanup = args.gif_cleanup
+    overwrite = args.gif_overwrite
+    lb_gif_flags = (lb, gif, cleanup, overwrite)
 
 
     # process args
@@ -170,7 +196,7 @@ def main():
                               video_file = args.video_file,
                               vid_sync = sync_input,
                               frame_extract = frames,
-                              extra_out = lb_gif_bbox
+                              extra_out = lb_gif_flags
                               )
 
 

--- a/src/ssoss/ssoss_gui.py
+++ b/src/ssoss/ssoss_gui.py
@@ -68,6 +68,8 @@ def main():
     video_sync_group.add_argument("-label", "--label", metavar="Overlay Image Label", help="Include descriptive label on bottom of image", action="store_true", default=True)
     video_sync_group.add_argument("-gif", "--gif", metavar="Create Animated GIF", help="Generate GIF of Sight Distance", action="store_true", default=False)
 
+    # GIF options available only through CLI; defaults are used here
+
     args = parser.parse_args()
 
     sync_input = ("", "")
@@ -77,19 +79,18 @@ def main():
     if args.frame_extract_start and args.frame_extract_end:
         frames = (args.frame_extract_start[0], args.frame_extract_end[0])
 
-    lb = gif = bbox = False
-    if args.label:
-        lb = True
-    if args.gif:
-        gif = True
-    lb_gif_bbox = (lb, gif, bbox)
+    lb = args.label
+    gif = args.gif
+    cleanup = True
+    overwrite = False
+    extra_out = (lb, gif, cleanup, overwrite)
 
     args_static_obj_gpx_video(generic_so_file = args.static_object_file,
                               gpx_file = args.gpx_file,
                               video_file = args.video_file,
                               vid_sync = sync_input,
                               frame_extract = frames,
-                              extra_out = lb_gif_bbox
+                              extra_out = extra_out
                               )
 
 


### PR DESCRIPTION
## Summary
- add `cleanup` and `overwrite` parameters to `assemble_gif`
- expose new CLI options `--no-gif-cleanup` and `--gif-overwrite`
- propagate options through `generate_gif`, `extract_*` functions, CLI and GUI
- document new GIF flags in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f3deac0c832b9b2bb7ae5f4ad324