### PR TITLE
Fix sync logging duplicates

### DIFF
--- a/src/ssoss/process_video.py
+++ b/src/ssoss/process_video.py
@@ -76,9 +76,20 @@ class ProcessVideo:
         # ensure the out directory exists before attempting to write
         sync_txt_folder.mkdir(exist_ok=True, parents=True)
         sync_file = sync_txt_folder / "sync.txt"
-        # open in append mode so the file is created if it doesn't exist
-        with open(sync_file, "a") as f:
-            f.write(f"{self.video_filepath.stem},{frame},{ts}\n")
+
+        sync_line = f"{self.video_filepath.stem},{frame},{ts}"
+        write_line = True
+        if sync_file.exists():
+            with open(sync_file, "r") as existing:
+                for line in existing:
+                    if line.strip() == sync_line:
+                        write_line = False
+                        break
+
+        if write_line:
+            # open in append mode so the file is created if it doesn't exist
+            with open(sync_file, "a") as f:
+                f.write(sync_line + "\n")
 
         elapsed_time = frame / self.fps
         if type(ts) is float:

--- a/src/ssoss/ssoss_cli.py
+++ b/src/ssoss/ssoss_cli.py
@@ -35,25 +35,32 @@ def args_static_obj_gpx_video(
         video = process_video.ProcessVideo(video_file.name)
         if vid_sync[0] and vid_sync[1]:
             video.sync(int(vid_sync[0]), vid_sync[1])
+
+            lb_flag = extra_out[0] if len(extra_out) > 0 else True
+            gif_flag = extra_out[1] if len(extra_out) > 1 else False
+            cleanup_flag = extra_out[2] if len(extra_out) > 2 else True
+            overwrite_flag = extra_out[3] if len(extra_out) > 3 else False
+
+            sig_kwargs = {"label_img": lb_flag, "gen_gif": gif_flag}
+            if len(extra_out) > 2:
+                sig_kwargs["cleanup"] = cleanup_flag
+            if len(extra_out) > 3:
+                sig_kwargs["overwrite"] = overwrite_flag
+
             if sightings and project.get_static_object_type() == "intersection":
                 print("extracting traffic signal sightings")
                 video.extract_sightings(
                     sightings,
                     project,
-                    label_img=extra_out[0],
-                    gen_gif=extra_out[1],
-                    cleanup=extra_out[2],
-                    overwrite=extra_out[3],
+                    **sig_kwargs,
                 )
+
             if sightings and project.get_static_object_type() == "generic static object":
                 print("extracting generic static object sightings")
                 video.extract_generic_so_sightings(
                     sightings,
                     project,
-                    label_img=extra_out[0],
-                    gen_gif=extra_out[1],
-                    cleanup=extra_out[2],
-                    overwrite=extra_out[3],
+                    **sig_kwargs,
                 )
         elif frame_extract[0] and frame_extract[1]:
             print("extracting frames...")

--- a/tests/test_process_video.py
+++ b/tests/test_process_video.py
@@ -58,6 +58,14 @@ class TestProcessVideo(unittest.TestCase):
             line = f.read().strip()
         self.assertEqual(line, f"{self.pv.video_filepath.stem},10,110.0")
 
+    def test_sync_does_not_duplicate_entry(self):
+        self.pv.sync(10, 110.0)
+        self.pv.sync(10, 110.0)
+        sync_file = pathlib.Path(self.pv.video_dir, "out", "sync.txt")
+        with open(sync_file) as f:
+            lines = f.readlines()
+        self.assertEqual(len(lines), 1)
+
     def _check_gps(self, image_path):
         exif = piexif.load(str(image_path))
         gps = exif.get("GPS", {})


### PR DESCRIPTION
## Summary
- avoid multiple identical lines in `sync.txt`
- tolerate shorter tuples for CLI gif options
- test for duplicate sync line handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f71caedc832b8064b655f4d41161