### PR TITLE
Prevent duplicate sync log entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ where ### is the frame number of the image.
 Use the frame number and the GPX recorded time to line up the best point to synchronize the video using the Sync method.
 
 ##### Sync.txt Logger
-Automatically saves frame number and timestamp to sync.txt file in the ./out/ directory so a log of when a video file was synchronized is saved.
+Automatically saves frame number and timestamp to sync.txt file in the ./out/ directory so a log of when a video file was synchronized is saved. Duplicate lines are ignored to prevent redundant entries.
 
 ### Sources of Error
 While SSOSS does provide approximate sight distance images, their are various sources of error that should be try to be minimized. Here are the major sources of error and how they can be mitigated.

--- a/src/ssoss/process_video.py
+++ b/src/ssoss/process_video.py
@@ -71,14 +71,21 @@ class ProcessVideo:
         """
         finds start time of video based on frame and timestamp
             appends frame # and timestamp to sync.txt with video filename for reference
+            duplicate entries are ignored
         """
         sync_txt_folder = Path(self.video_dir, "out")
         # ensure the out directory exists before attempting to write
         sync_txt_folder.mkdir(exist_ok=True, parents=True)
         sync_file = sync_txt_folder / "sync.txt"
-        # open in append mode so the file is created if it doesn't exist
-        with open(sync_file, "a") as f:
-            f.write(f"{self.video_filepath.stem},{frame},{ts}\n")
+        line = f"{self.video_filepath.stem},{frame},{ts}"
+        existing_lines = set()
+        if sync_file.exists():
+            with open(sync_file, "r") as f:
+                existing_lines = {l.strip() for l in f}
+        if line not in existing_lines:
+            # open in append mode so the file is created if it doesn't exist
+            with open(sync_file, "a") as f:
+                f.write(line + "\n")
 
         elapsed_time = frame / self.fps
         if type(ts) is float:

--- a/tests/test_process_video.py
+++ b/tests/test_process_video.py
@@ -58,6 +58,14 @@ class TestProcessVideo(unittest.TestCase):
             line = f.read().strip()
         self.assertEqual(line, f"{self.pv.video_filepath.stem},10,110.0")
 
+    def test_sync_does_not_duplicate_lines(self):
+        self.pv.sync(10, 110.0)
+        self.pv.sync(10, 110.0)
+        sync_file = pathlib.Path(self.pv.video_dir, "out", "sync.txt")
+        with open(sync_file) as f:
+            lines = [l.strip() for l in f]
+        self.assertEqual(lines, [f"{self.pv.video_filepath.stem},10,110.0"])
+
     def _check_gps(self, image_path):
         exif = piexif.load(str(image_path))
         gps = exif.get("GPS", {})


### PR DESCRIPTION
## Summary
- avoid duplicating lines in `sync.txt`
- note this behavior in README
- test that `sync` does not append duplicates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a62dab58c832bb67f4dd3fa83e276