### PR TITLE
Add autosync CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Collect data simultaneously:
                          --video_file vid.mov \
                          --sync_frame 456 \
                          --sync_timestamp 2022-10-24T14:21:54.32Z
+
+(ssoss_virtual_env) ssoss --video_file 09-15-2023--14-12-24.123-UTC.mov \
+                         --autosync
 ```
 
 #### Sync GPX & Video Process

--- a/src/ssoss/ssoss_cli.py
+++ b/src/ssoss/ssoss_cli.py
@@ -1,6 +1,46 @@
 import argparse
+import re
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
 from . import process_road_objects
 from . import process_video
+
+
+def _timestamp_from_filename(path: str) -> str:
+    """Extract ISO 8601 timestamp from ``path``.
+
+    The filename should contain a timestamp formatted as
+    ``MM-DD-YYYY--HH-MM-SS.sss-ZZZ`` where ``ZZZ`` is a timezone
+    abbreviation such as ``UTC`` or ``PDT``.
+    """
+
+    base = Path(path).stem
+    m = re.search(
+        r"(?P<ts>\d{2}-\d{2}-\d{4}--\d{2}-\d{2}-\d{2}\.\d+)-(?P<zone>[A-Za-z]+)$",
+        base,
+    )
+    if not m:
+        raise ValueError("No timestamp found in video filename")
+
+    ts_str = m.group("ts")
+    zone = m.group("zone")
+
+    dt = datetime.strptime(ts_str, "%m-%d-%Y--%H-%M-%S.%f")
+    zone_map = {
+        "UTC": "UTC",
+        "PST": "America/Los_Angeles",
+        "PDT": "America/Los_Angeles",
+        "MST": "America/Denver",
+        "MDT": "America/Denver",
+        "CST": "America/Chicago",
+        "CDT": "America/Chicago",
+        "EST": "America/New_York",
+        "EDT": "America/New_York",
+    }
+    tz_name = zone_map.get(zone.upper(), "UTC")
+    dt = dt.replace(tzinfo=ZoneInfo(tz_name))
+    return dt.isoformat()
 
 
 def args_static_obj_gpx_video(
@@ -139,6 +179,11 @@ def main():
         help="2. Sync Timestamp ('2022-10-24T14:21:54.988Z') for video. Sync with frame number also",
         type=str,
     )
+    video_sync_group.add_argument(
+        "--autosync",
+        action="store_true",
+        help="Sync using timestamp embedded in video filename",
+    )
 
     video_sync_group.add_argument(
         "--label",
@@ -175,7 +220,15 @@ def main():
 
     sync_input = ("", "")
     frames = ("", "")
-    if args.sync_frame and args.sync_timestamp:
+    if args.autosync:
+        if not args.video_file:
+            parser.error("--autosync requires --video_file")
+        try:
+            ts = _timestamp_from_filename(args.video_file.name)
+            sync_input = (1, ts)
+        except ValueError as e:
+            parser.error(str(e))
+    elif args.sync_frame and args.sync_timestamp:
         sync_input = (args.sync_frame, args.sync_timestamp)
     if args.frame_extract_start and args.frame_extract_end:
         frames = (args.frame_extract_start[0], args.frame_extract_end[0])

--- a/tests/test_ssoss_cli.py
+++ b/tests/test_ssoss_cli.py
@@ -103,3 +103,13 @@ def test_dispatch_extract_frames(monkeypatch, tmp_path):
 
     pv_instance.extract_frames_between.assert_called_once_with(1, 2)
 
+
+def test_autosync_uses_filename(run_cli, tmp_path):
+    vid = tmp_path / "09-15-2023--14-12-24.123-UTC.mov"
+    vid.write_text("data")
+
+    result = run_cli(["--video_file", str(vid), "--autosync"])
+
+    assert result["vid_sync"][0] == 1
+    assert result["vid_sync"][1].startswith("2023-09-15T14:12:24.123000")
+


### PR DESCRIPTION
## Summary
- support `--autosync` flag for CLI
- parse timestamp from video filename
- update example usage in README
- test autosync logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc1528208832b9ae7c0986c966431