### PR TITLE
Improve CLI help output

### DIFF
--- a/src/ssoss/cli.py
+++ b/src/ssoss/cli.py
@@ -5,12 +5,25 @@ from . import ssoss_cli
 from .signal_layer import build_signal_layer
 
 
-@click.group(invoke_without_command=True, context_settings={"help_option_names": ["-h", "--help"]})
+@click.group(invoke_without_command=True, add_help_option=False)
+@click.option("-h", "--help", "show_help", is_flag=True, is_eager=True,
+              help="Show this message and exit.")
 @click.pass_context
-def cli(ctx):
+def cli(ctx, show_help):
     """SSOSS command line interface."""
     if ctx.invoked_subcommand is None:
-        ssoss_cli.main()
+        if show_help:
+            try:
+                ssoss_cli.main(["--help"])
+            except SystemExit:
+                pass
+            if cli.commands:
+                click.echo("\nCommands:")
+                for name, cmd in cli.commands.items():
+                    click.echo(f"  {name:<20} {cmd.get_short_help_str()}")
+            ctx.exit()
+        else:
+            ssoss_cli.main()
 
 
 cli.add_command(build_signal_layer)

--- a/src/ssoss/ssoss_cli.py
+++ b/src/ssoss/ssoss_cli.py
@@ -102,7 +102,7 @@ def args_static_obj_gpx_video(
             video.extract_frames_between(frame_extract[0], frame_extract[1])
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         prog="Safe Sightings of Signs and Signals",
         description="Software to help verify visible traffic signs and signals using GPX and Video files",
@@ -216,7 +216,7 @@ def main():
     )
 
     # process args depending on filled in values
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     sync_input = ("", "")
     frames = ("", "")


### PR DESCRIPTION
## Summary
- support argv argument in `ssoss_cli.main`
- add custom `--help` handler in `cli` to show argparse help plus subcommands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9640becc832b820ad8021737cdfb