### PR TITLE
Improve video sync summary

### DIFF
--- a/src/ssoss/process_video.py
+++ b/src/ssoss/process_video.py
@@ -37,6 +37,8 @@ class ProcessVideo:
         self.duration = self.get_duration()
         self.start_time = 0
         self.capture = ""
+        self.sync_frame = None
+        self.sync_timestamp = None
 
 
         self.vid_summary(vid_summary=True)
@@ -94,6 +96,8 @@ class ProcessVideo:
             t_temp = (dateutil.parser.isoparse(ts))  #  isoparse parses ISO-8601 datetime string into datetime.datetime
             start_time = t_temp.replace(tzinfo=timezone.utc).timestamp() - elapsed_time
         self.set_start_utc(start_time)
+        self.sync_frame = frame
+        self.sync_timestamp = ts
         self.vid_summary(vid_summary=False, sync=True)
         return None
 
@@ -408,6 +412,10 @@ class ProcessVideo:
         file_byte = os.path.getsize(self.video_filepath)
         return self.sizeConvert(file_byte)
 
+    def get_filesize_bytes(self):
+        """Return the raw file size in bytes."""
+        return os.path.getsize(self.video_filepath)
+
     def vid_summary(self, vid_summary, sync=False):
         #  display values
         width = 70
@@ -420,6 +428,11 @@ class ProcessVideo:
             # get vcap property
             vid_width = vid_file.get(cv2.CAP_PROP_FRAME_WIDTH)  # float `width`
             vid_height = vid_file.get(cv2.CAP_PROP_FRAME_HEIGHT)  # float `height`
+        else:
+            vid_width = vid_height = 0
+        file_bytes = self.get_filesize_bytes()
+        data_rate = round(file_bytes / self.get_duration() / (1024 * 1024), 2)
+        avg_frame_size = round(file_bytes / self.frame_count / 1024, 2)
 
         summary = f"""
                 {symbol * width}
@@ -431,6 +444,8 @@ class ProcessVideo:
                 # Frames Per Second: {self.fps}
                 # Total Number of Frames: {self.frame_count:,}
                 # Total Duration: {self.hr_min_sec(self.get_duration())}
+                # Avg. Frame Size: {avg_frame_size} KB
+                # Data Rate: {data_rate} MB/sec
                 {symbol * width}
                 """
 
@@ -438,8 +453,12 @@ class ProcessVideo:
                     {symbol * width}
                     {" " * (int(width/2)-int(len(sync_title)/2))}{sync_title}
                     {symbol * width}
+                    # Sync Frame: {self.sync_frame}
+                    # Sync Timestamp: {self.sync_timestamp}
                     # Start Time: {datetime.fromtimestamp(self.start_time, tz=None)}
                     # End Time:   {datetime.fromtimestamp(self.start_time + self.get_duration(), tz=None)}
+                    # Avg. Frame Size: {avg_frame_size} KB
+                    # Data Rate: {data_rate} MB/sec
                     {symbol * width}
                     """
         if vid_summary:


### PR DESCRIPTION
## Summary
- record frame and timestamp when syncing
- compute file byte size for bitrate
- print frame and bitrate info in video summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c991966b8832b929b00245a80dc9e