### PR TITLE
Improve sync summary formatting

### DIFF
--- a/src/ssoss/process_video.py
+++ b/src/ssoss/process_video.py
@@ -37,6 +37,7 @@ class ProcessVideo:
         self.duration = self.get_duration()
         self.start_time = 0
         self.capture = ""
+        self.sync_source = "Not synced"
 
 
         self.vid_summary(vid_summary=True)
@@ -67,11 +68,13 @@ class ProcessVideo:
         else:
             return timedelta(seconds=self.duration)
 
-    def sync(self, frame: int, ts):
+    def sync(self, frame: int, ts, autosync: bool = False):
         """
         finds start time of video based on frame and timestamp
             appends frame # and timestamp to sync.txt with video filename for reference
             duplicate entries are ignored
+            ``autosync`` indicates the timestamp was derived from the
+            filename rather than provided explicitly
         """
         sync_txt_folder = Path(self.video_dir, "out")
         # ensure the out directory exists before attempting to write
@@ -93,6 +96,10 @@ class ProcessVideo:
         else:
             t_temp = (dateutil.parser.isoparse(ts))  #  isoparse parses ISO-8601 datetime string into datetime.datetime
             start_time = t_temp.replace(tzinfo=timezone.utc).timestamp() - elapsed_time
+        if autosync:
+            self.sync_source = "Auto sync using filename timestamp"
+        else:
+            self.sync_source = f"Frame {frame} at {ts}"
         self.set_start_utc(start_time)
         self.vid_summary(vid_summary=False, sync=True)
         return None
@@ -438,6 +445,8 @@ class ProcessVideo:
                     {symbol * width}
                     {" " * (int(width/2)-int(len(sync_title)/2))}{sync_title}
                     {symbol * width}
+                    # Video File: {self.video_filename}
+                    # Sync Source: {self.sync_source}
                     # Start Time: {datetime.fromtimestamp(self.start_time, tz=None)}
                     # End Time:   {datetime.fromtimestamp(self.start_time + self.get_duration(), tz=None)}
                     {symbol * width}

--- a/src/ssoss/ssoss_cli.py
+++ b/src/ssoss/ssoss_cli.py
@@ -58,6 +58,7 @@ def args_static_obj_gpx_video(
     vid_sync=("", ""),
     frame_extract=("", ""),
     extra_out=(True, False, True, False),
+    autosync=False,
 ):
 
     sightings = ""
@@ -88,7 +89,7 @@ def args_static_obj_gpx_video(
     if video_file:
         video = process_video.ProcessVideo(video_file.name)
         if vid_sync[0] and vid_sync[1]:
-            video.sync(int(vid_sync[0]), vid_sync[1])
+            video.sync(int(vid_sync[0]), vid_sync[1], autosync=autosync)
             if sightings and project.get_static_object_type() == "intersection":
                 print("extracting traffic signal sightings")
                 kwargs = {"label_img": extra_out[0], "gen_gif": extra_out[1]}
@@ -259,7 +260,8 @@ def main(argv=None):
                               video_file = args.video_file,
                               vid_sync = sync_input,
                               frame_extract = frames,
-                              extra_out = lb_gif_flags
+                              extra_out = lb_gif_flags,
+                              autosync = args.autosync
                               )
 
 

--- a/tests/test_ssoss_cli.py
+++ b/tests/test_ssoss_cli.py
@@ -79,7 +79,7 @@ def test_dispatch_sync_calls(monkeypatch, tmp_path):
             extra_out=(True, False),
         )
 
-    pv_instance.sync.assert_called_once_with(1, "ts")
+    pv_instance.sync.assert_called_once_with(1, "ts", autosync=False)
     pv_instance.extract_sightings.assert_called_once_with(
         ["sig"], pr_instance, label_img=True, gen_gif=False
     )


### PR DESCRIPTION
## Summary
- expand `ProcessVideo.sync` to record sync source
- include filename and sync source in printed sync summary
- pass `autosync` flag through CLI
- update CLI tests for new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c98f8cc0c832bb00e9e0c04ef9069